### PR TITLE
Add an extension trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # unicode-categories
-Traits and methods to extend the char type with unicode-category metadata
+This crate provides a method and Extension Trait on top of the `char` type
+for returning a corresponding Unicode General Category as defined in the
+[latest standard](https://www.unicode.org/versions/Unicode14.0.0/UnicodeStandard-14.0.pdf).
+
+## Including the crate
+For now the crate can be included by branch or by tag via git.
+
+```toml
+#[dependencies]
+unicode-categories = { git = "https://github.com/ncatelli/unicode_categories", branch = "main" }
+```
+
+## Examples
+
+Using the `char` type extension trait.
+
+```rust
+use unicode_categories::UnicodeCategorizable;
+
+assert_eq!(Some(Category::Lu), 'A'.unicode_category());
+assert_eq!(Some(Category::Ll), 'a'.unicode_category());
+```
+
+Using the include conversion method:
+
+```rust
+use unicode_categories::unicode_category_from_char;
+
+assert_eq!(Some(Category::Lu), unicode_category_from_char('A'));
+assert_eq!(Some(Category::Ll), unicode_category_from_char('a'));
+```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ unicode-categories = { git = "https://github.com/ncatelli/unicode_categories", b
 Using the `char` type extension trait.
 
 ```rust
-use unicode_categories::UnicodeCategorizable;
+use unicode_categories::*;
 
 assert_eq!(Some(Category::Lu), 'A'.unicode_category());
 assert_eq!(Some(Category::Ll), 'a'.unicode_category());
@@ -25,7 +25,7 @@ assert_eq!(Some(Category::Ll), 'a'.unicode_category());
 Using the include conversion method:
 
 ```rust
-use unicode_categories::unicode_category_from_char;
+use unicode_categories::*;
 
 assert_eq!(Some(Category::Lu), unicode_category_from_char('A'));
 assert_eq!(Some(Category::Ll), unicode_category_from_char('a'));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,27 @@
 include!(concat!(env!("OUT_DIR"), "/unicode_mappings.rs"));
 
+/// Provides extention methods to allow `char` to optionally return it's
+/// associated unicode category.
+pub trait UnicodeCategorizable {
+    fn unicode_category(&self) -> Option<Category>;
+}
+
+impl UnicodeCategorizable for char {
+    /// Returns a `char`'s corresponding general unicode category or returns none.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use unicode_categories::*;
+    ///
+    /// assert_eq!(Some(Category::Lu), 'A'.unicode_category());
+    /// assert_eq!(Some(Category::Ll), 'a'.unicode_category());
+    /// ```
+    fn unicode_category(&self) -> Option<Category> {
+        unicode_category_from_char(*self)
+    }
+}
+
 /// A unicode general category.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Category {
@@ -257,6 +279,15 @@ impl From<Category> for HumanReadableCategory {
 /// Generates a corresponding general unicode category for a provide char. If
 /// the character isn't a member of a general category, `Option::None` is
 /// returned.
+///
+/// # Example
+///
+/// ```
+/// use unicode_categories::*;
+///
+/// assert_eq!(Some(Category::Lu), unicode_category_from_char('A'));
+/// assert_eq!(Some(Category::Ll), unicode_category_from_char('a'));
+/// ```
 pub fn unicode_category_from_char(c: char) -> Option<Category> {
     unicode_category_str_from_char(c).and_then(Category::from_category_str)
 }
@@ -282,5 +313,11 @@ mod tests {
             Some(HumanReadableCategory::LetterLowercase),
             lower_cat.map(HumanReadableCategory::from)
         );
+    }
+
+    #[test]
+    fn should_map_letter_category_for_extention_trait() {
+        assert_eq!(Some(Category::Lu), 'A'.unicode_category());
+        assert_eq!(Some(Category::Ll), 'a'.unicode_category());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,27 @@
+//! This crate provides a method and Extension Trait on top of the `char` type
+//! for returning a corresponding Unicode General Category as defined in the
+//! [latest standard](https://www.unicode.org/versions/Unicode14.0.0/UnicodeStandard-14.0.pdf).
+//!
+//! # Examples
+//!
+//! Using the `char` type extension trait.
+//!
+//! ```
+//! use unicode_categories::UnicodeCategorizable;
+//!
+//! assert_eq!(Some(Category::Lu), 'A'.unicode_category());
+//! assert_eq!(Some(Category::Ll), 'a'.unicode_category());
+//! ```
+//!
+//! Using the include conversion method:
+//!
+//! ```
+//! use unicode_categories::unicode_category_from_char;
+//!
+//! assert_eq!(Some(Category::Lu), unicode_category_from_char('A'));
+//! assert_eq!(Some(Category::Ll), unicode_category_from_char('a'));
+//! ```
+
 include!(concat!(env!("OUT_DIR"), "/unicode_mappings.rs"));
 
 /// Provides extention methods to allow `char` to optionally return it's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! Using the `char` type extension trait.
 //!
 //! ```
-//! use unicode_categories::UnicodeCategorizable;
+//! use unicode_categories::*;
 //!
 //! assert_eq!(Some(Category::Lu), 'A'.unicode_category());
 //! assert_eq!(Some(Category::Ll), 'a'.unicode_category());
@@ -16,7 +16,7 @@
 //! Using the include conversion method:
 //!
 //! ```
-//! use unicode_categories::unicode_category_from_char;
+//! use unicode_categories::*;
 //!
 //! assert_eq!(Some(Category::Lu), unicode_category_from_char('A'));
 //! assert_eq!(Some(Category::Ll), unicode_category_from_char('a'));


### PR DESCRIPTION
# Introduction
This PR introduces an extension trait allowing the `char.unicode_category` method for optionally returning a character types unicode category.

```rust
use unicode_categories::*;

assert_eq!(Some(Category::Lu), 'A'.unicode_category());
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
