### PR TITLE
Typo Fix: leters -> letters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl UnicodeCategorizable for char {
 /// A unicode general category.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Category {
-    // Leters
+    // Letters
     Lu,
     Ll,
     Lt,


### PR DESCRIPTION
# Introduction
Small typo fix in the unicode category enum, fixing the `Letters` docstring from `Leters`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
